### PR TITLE
Add initial router for the recruit service

### DIFF
--- a/scripts/services/recruit.js
+++ b/scripts/services/recruit.js
@@ -1,0 +1,26 @@
+var recruit_service_keywords = ['hire', 'recruit', 'employ'];
+
+function main() {
+    // Process all incoming messages and determine the correct service
+    // to route the user to.
+
+    var msg_contains = function(word) {
+        // Test whether the message (global) contains the given word
+        var msg = (message.content || '').toLowerCase();
+        return msg.indexOf(word.toLowerCase()) !== -1;
+    };
+    
+    var invoke_with_msg = function(service_id) {
+        // Invoke a service by ID and pass the incoming message to it for context
+        var service_obj = project.initServiceById(service_id);
+        service_obj.invoke({
+            context: 'message',
+            event: 'incoming_message',
+            message_id: message.id,
+        });
+    }
+    
+    if (recruit_service_keywords.some(msg_contains)) {
+        invoke_with_msg(contact.vars.recruit_service);
+    }
+}


### PR DESCRIPTION
Initially I had though each 'top-level' service (recruit, offer, choose, survey) would have its own router, but now I think it makes sense to have a single router service.

This will require refactoring and drying out as I develop subsequent routers, but I've kept it simple for the moment.

The main function is executed by the telerivet script runner, and `message`, `project` and `contact` are globals.